### PR TITLE
fix(docker): ignore npm scripts during install


### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /tmp
 
 # hadolint ignore=DL3018
 COPY ./package* /tmp
-RUN npm install
+RUN npm install --ignore-scripts
 # hadolint ignore=DL3059
 RUN	npm version ${BUILD} --allow-same-version &&\
 	npx genversion version.js
@@ -24,7 +24,7 @@ WORKDIR ${READ2BURN_HOME}
 # hadolint ignore=DL3018
 RUN apk add --no-cache tzdata
 COPY ./package* ${READ2BURN_HOME}
-RUN npm ci --only=production
+RUN npm ci --only=production --ignore-scripts
 COPY ./ ${READ2BURN_HOME}
 COPY --from=version /tmp/version.js ${READ2BURN_HOME}
 RUN rm -rf ${READ2BURN_HOME}/docker


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add --ignore-scripts to npm install step

- Add --ignore-scripts to npm ci production

- Prevent package scripts in Docker builds


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Ignore scripts in npm install commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<li>Added --ignore-scripts flag to npm install.<br> <li> Added --ignore-scripts flag to npm ci production.


</details>


  </td>
  <td><a href="https://github.com/danstis/read2burn/pull/222/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>